### PR TITLE
Fix test function name in eval.c

### DIFF
--- a/sources/forth_modoki/05_eval_num/eval.c
+++ b/sources/forth_modoki/05_eval_num/eval.c
@@ -35,7 +35,7 @@ static void test_eval_num_two() {
 }
 
 
-static void test_eval_add() {
+static void test_eval_num_add() {
     char *input = "1 2 add";
     int expect = 3;
 


### PR DESCRIPTION
Fix test function name in eval.c:
from `test_eval_add()` to `test_eval_num_add()`.