### PR TITLE
Fix typo in 07_hash

### DIFF
--- a/forth_modoki.md
+++ b/forth_modoki.md
@@ -1121,7 +1121,7 @@ dict_put()の場合なら、
 void dict_put(char* key, int value) {
     int idx = hash(key);
     struct Node *head = array[idx];
-    if(head == nul) {
+    if(head == NULL) {
        headをallocする
        head->next = NULL;
        headのkeyとvalueをセット;


### PR DESCRIPTION
ハッシュテーブルの説明に掲載されている擬似コードのNULLがnulとなっていたのを修正しました。