### PR TITLE
Add a function to get all inputs by cl_printf()

### DIFF
--- a/sources/arm_asm/04_disasm/cl_utils.c
+++ b/sources/arm_asm/04_disasm/cl_utils.c
@@ -1,7 +1,8 @@
 #include <stdarg.h>
-
+#include <stdio.h>
 
 static char buf[100*1024];
+static char buf2[100*1024];
 
 static int to_buffer = 0;
 static int pos = 0;
@@ -22,6 +23,23 @@ char *cl_get_result(int num) {
         i++;
     }
     return &buf[i];
+}
+
+char *cl_get_all_result() {
+    int p = 0;
+    int p2 = 0;
+
+    while (p < pos) {
+        if (buf[p] == '\0') {
+            p++;
+            continue;
+        }
+
+        buf2[p2++] = buf[p++];
+    }
+    buf2[p2] = '\0';
+
+    return buf2;
 }
 
 void cl_enable_buffer_mode() {

--- a/sources/arm_asm/04_disasm/cl_utils.c
+++ b/sources/arm_asm/04_disasm/cl_utils.c
@@ -1,5 +1,5 @@
 #include <stdarg.h>
-#include <stdio.h>
+
 
 static char buf[100*1024];
 static char buf2[100*1024];


### PR DESCRIPTION
This PR is for assembler/disassembler chapter.

The function added in this PR can get all inputs  made by `cl_printf()` as a string.

`cl_printf()` adds `\0` at the end of its input, so it cannot get all inputs as a string. If the reader chooses to construct each lines by calling `cl_printf()` multiple times, they cannot get entire inputs by `cl_get_result(0)`at once.

This PR resolves such situations.

