### PR TITLE
Remove a symbol does not appear in `many_symbols.c`

### DIFF
--- a/casm_link_load.md
+++ b/casm_link_load.md
@@ -672,7 +672,7 @@ many_symbols.cには、シンボルにかかわる限り、以下の要素があ
 |---- | ---- |
 | 未初期化のグローバル変数定義| g_in_hello_uninit, g_text_uninit, g_large_buf |
 | 初期化のあるグローバル変数定義| g_in_hello, g_text, g_text_arr |
-| staticなグローバル変数 | g_static_in_hello, g_static_in_hello2 |
+| staticなグローバル変数 | g_static_in_hello |
 | staticな未初期化グローバル変数 | g_static_uninit |
 | グローバル変数の宣言 | g_in_main |
 | 関数の定義 | print_something | 


### PR DESCRIPTION
第三回を最初からやりなおしていたところ「03 リンク入門」の「Cのコードと三つのセクションの対応」にあるmany_symbols.c内シンボル分類表に、実際のmany_symbols.cには存在しないシンボルが書かれているのを見つけました。このPRはそれを削除するものです。

`git grep g_static_in_hello2`してcasm_link_load.mdの該当箇所以外ひっかからないので、過去の名残りかなにかだと思います。