### PR TITLE
Fix early return of `begin_with_len()`

### DIFF
--- a/sources/casm_link/06_jit_ps/parser.c
+++ b/sources/casm_link/06_jit_ps/parser.c
@@ -46,7 +46,7 @@ int is_end(struct Substr *in_str) {
 
 int begin_with_len(struct Substr *in_str, char *expect, int expect_len) {
     int pos = 0;
-    if(in_str->len > in_str->len)
+    if(in_str->len < expect_len)
         return 0;
     while(in_str->ptr[pos] == expect[pos] && pos < expect_len) {
         pos++;


### PR DESCRIPTION
ここの early return は、Prefix としてチェックする `expect` の 文字長が、本体の文字列 `in_str` より長い場合のチェックだと思うので、そのように修正した。